### PR TITLE
Fix split failure double free

### DIFF
--- a/src/split_cmd.c
+++ b/src/split_cmd.c
@@ -55,10 +55,13 @@ void	free_partial_tab(char **argv, int count)
 	if (!argv)
 		return ;
 	i = 0;
-	while (i < count && argv[i])
+	while (i < count)
 	{
-		free(argv[i]);
+		if (argv[i])
+		{
+			free(argv[i]);
+			argv[i] = NULL;
+		}
 		i++;
 	}
-	free(argv);
 }


### PR DESCRIPTION
## Summary
- avoid freeing the argv container inside `free_partial_tab` so `split_cmd_simple` can release it safely after a split failure
- null out the entries that were freed to prevent accidental re-use

## Testing
- make re
- MALLOC_CHECK_=2 ./pipex infile "echo 'hello" "wc -c" outfile

------
https://chatgpt.com/codex/tasks/task_e_68cbffd0f5908323ae1231e246cee1d1